### PR TITLE
Versionen från 2016-07-01

### DIFF
--- a/SKOS-style3.xsl
+++ b/SKOS-style3.xsl
@@ -1,20 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0"?>
 
-<!--Inlämningsuppgift XSL, Kunskapsorganisation 2: XML och bibliografisk kontroll, Maria Idebrant, DV09 2011-05-05-->
-
-<!--Ändringar i stilmallen:
-	- BT skrivs ut när de finns. UF skrivs inte ut när den saknar innehåll.
-	- USE är en länk precis som BT & NT, eftersom det är rimligt att man vill hitta rätt term smidigt.
-	- Text i skos:example skrivs ut.
-	- Länkningen inom sidan fungerar.
-	- Tabellen är borta. Jag föredrar div:ar för att  koden blir mer överskådlig och det är lättare att använda css:en bra.
-	- Alla stilangivelser är flyttade till stilmallen.
-	- Har ändrat bredd och lite andra småsaker för att det ska bli lite trevligare att läsa enligt min smak. Till exempel kan rött mot vitt vara svårt att läsa, varför jag valde svart istället. Den gamla stilmallen ger jobbigt långt avstånd mellan vänsterspalten och de båda spalterna till höger också, om man har för bred skärm, så jag har minskat ned det. 
-	- Ifall rdf:resource har stavats fel skrivs ett felmeddelande ut där länken skulle varit, istället för att det bara blir en tomrad. Det är lätt att man missar en tomrad, så detta blir lite tydligare.
-	- Om man har skrivit in att term A har en relation till term B, men missat att skriva in att term B har motsvarande relation till term A, kommer det att skrivas ut efter länken från term A till term B. Betydligt enklare att se ifall man missat någonting då än att kolla igenom xml-filen själv.
-
-Vill man så kan man naturligtvis lägga till att fler element ska skrivas ut, t ex skos:historyNote, men jag tycker att det räcker bra med de som är i dtd:n.
--->
+<!-- Senast ändrad 2016-07-01 // Mikael Gunnarsson, Maria Idebrant -->
 
 <xsl:stylesheet version="1.0" 
 xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
@@ -23,8 +9,7 @@ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 xmlns:skos="http://www.w3.org/2004/02/skos/core#" 
 xmlns:dc="http://purl.org/dc/elements/1.1/">
 	
-	<xsl:output method="xml" indent="yes" doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN" doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd" media-type="application/xhtml+xml" encoding="utf-8"/>
-	
+	<xsl:output method="xml" indent="yes" doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN" doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd" media-type="application/xhtml+xml"/>
 	
 	<xsl:template match="/">
 		<html xmlns="http://www.w3.org/1999/xhtml">
@@ -49,19 +34,20 @@ xmlns:dc="http://purl.org/dc/elements/1.1/">
 				  }
 				  .uppslag {	/* uppslagsorden*/
 				  float : left;
+				  width : 35%;
 				  }
 				  .right {
-				  float : right;
-				  width : 80%;
+				  float : left;
+				  width : 65%;
 				  }
 				  .notering {	/*mittenfältet med UF, SN etc*/
 				  float : left;
-				  width : 30%;
+				  width : 40%;
 				  font-weight : bold;
 				  }
 				  .text {		/*högra fältet med länkar, beskrivningar etc*/
 				  float : right;
-				  width : 70%;
+				  width : 60%;
 				  }
 				  .notering, .text, p {
 				  padding-bottom : 1em;
@@ -69,9 +55,12 @@ xmlns:dc="http://purl.org/dc/elements/1.1/">
 				  .clear {
 				  clear : both;
 				  }
-				  .alt {		/*icke föredragna termer*/
+				  .alt {		/*icke föredragna namn*/
 				  font-size : 0.9em;
 				  font-weight : normal;
+				  }
+				  .error{		/*felmeddelanden*/
+				  color: #a00;
 				  }
 				</style>
 			</head>
@@ -82,9 +71,16 @@ xmlns:dc="http://purl.org/dc/elements/1.1/">
 				<h2>
 					<xsl:value-of select="rdf:RDF/skos:ConceptScheme/dc:description"/>
 				</h2>
-                <p>
-                  <xsl:value-of select="rdf:RDF/skos:ConceptScheme/dc:creator"/>
-                </p>
+				
+				<p>
+				<xsl:for-each select="rdf:RDF/skos:ConceptScheme/dc:creator">
+					<xsl:value-of select="."/>
+<br />
+				</xsl:for-each>
+				</p>
+
+				
+				
 				<xsl:for-each select="//skos:prefLabel | //skos:altLabel">
 					<xsl:sort select="." order="ascending"/>
 					<xsl:apply-templates select="."/>
@@ -92,9 +88,12 @@ xmlns:dc="http://purl.org/dc/elements/1.1/">
 			</body>
 		</html>
 	</xsl:template>
+	
 	<xsl:template match="skos:prefLabel">
 		<div class="post clear">
-				<h3 class="uppslag">
+				<div class="uppslag">
+				<h3>
+					<!--lägger till konceptets id som id på taggen h3, för att kunna länka till enskilda uppslagsnamn-->
 					<xsl:choose>
 						<xsl:when test="parent::skos:Concept/@rdf:about[starts-with(., '#')]"><!--kollar ifall id:t börjar med # -->
 							<xsl:attribute name="id">
@@ -107,8 +106,26 @@ xmlns:dc="http://purl.org/dc/elements/1.1/">
 							</xsl:attribute>
 						</xsl:otherwise>
 					</xsl:choose>
+					
+					
+					<!--och lägger till konceptets föredragna namn som innehåll i h3-->
 					<xsl:value-of select="."/>
+					
 				</h3>
+				<xsl:variable name="prefLabel">
+						<xsl:value-of select="."/>
+				</xsl:variable>
+				<xsl:if test="count(/rdf:RDF/skos:Concept[skos:prefLabel=$prefLabel])>1 or count(/rdf:RDF/skos:Concept[skos:altLabel=$prefLabel])>0 or count(/rdf:RDF/skos:Concept[skos:hiddenLabel=$prefLabel])>0"><p class="error">Det finns fler koncept med &quot;<xsl:value-of select="."/>
+&quot; som föredraget, alternativt eller dolt namn.</p></xsl:if>
+				
+				<xsl:variable name="id">
+						<xsl:value-of select="parent::skos:Concept/@rdf:about"/>
+				</xsl:variable>
+				<xsl:if test="count(/rdf:RDF/skos:Concept[@rdf:about=$id])>1"><p class="error">Det finns fler koncept som har &quot;<xsl:value-of select="$id"/>
+&quot; som ID. Värdet i rdf:about måste vara unikt.</p></xsl:if>
+				<xsl:if test="parent::skos:Concept/@rdf:about[contains(., ' ')]"> <p class="error">Du har angett &quot;<xsl:value-of select="$id" />&quot; som ID för detta koncept. Använd inte IDn med mellanslag.</p></xsl:if>
+				
+				</div>
 				<div class="right">
 					<xsl:if test="../skos:altLabel">
 						<div class="clear">
@@ -118,7 +135,13 @@ xmlns:dc="http://purl.org/dc/elements/1.1/">
 							<div class="text">
 								<xsl:for-each select="../skos:altLabel">
 									<xsl:value-of select="."/>
-									<br/>
+<br />
+																		
+									<xsl:variable name="altLabel">
+										<xsl:value-of select="."/>
+									</xsl:variable>
+									<xsl:if test="count(/rdf:RDF/skos:Concept[skos:prefLabel=$altLabel])>0 or count(/rdf:RDF/skos:Concept[skos:altLabel=$altLabel])>1 or count(/rdf:RDF/skos:Concept[skos:hiddenLabel=$altLabel])>0"><p class="error">Det finns fler koncept med &quot;<xsl:value-of select="."/>
+&quot; som föredraget, alternativt eller dolt namn.</p></xsl:if>
 								</xsl:for-each>
 							</div>
 						</div>
@@ -130,8 +153,16 @@ xmlns:dc="http://purl.org/dc/elements/1.1/">
 					</div>
 							<div class="text">
 								<xsl:for-each select="../skos:scopeNote">
+								<xsl:if test="@rdf:resource">
+										<a>
+											<xsl:attribute name="href">
+												<xsl:value-of select="@rdf:resource"/>
+											</xsl:attribute>
+											<xsl:value-of select="@rdf:resource"/>
+										</a>
+										<br/>
+									</xsl:if>
 									<xsl:value-of select="."/>
-									<br/>
 								</xsl:for-each>
 							</div>
 						</div>
@@ -158,7 +189,7 @@ xmlns:dc="http://purl.org/dc/elements/1.1/">
 		
 									<xsl:for-each select="//skos:Concept[@rdf:about=$relateradTerm]">
 										<xsl:if test="count(skos:narrower[@rdf:resource=$aktuelltKoncept] | skos:narrowerTransitive[@rdf:resource=$aktuelltKoncept])!=1">
-										 (Korrekt NT för <xsl:value-of select="skos:prefLabel"/> saknas.)
+										 <p class="error">Konceptet med föredraget namn &quot;<xsl:value-of select="skos:prefLabel"/>&quot; saknar skos:narrower till detta koncept.</p>
 										</xsl:if>
 									</xsl:for-each>
 									
@@ -189,7 +220,7 @@ xmlns:dc="http://purl.org/dc/elements/1.1/">
 		
 									<xsl:for-each select="//skos:Concept[@rdf:about=$relateradTerm]">
 										<xsl:if test="count(skos:broader[@rdf:resource=$aktuelltKoncept] | skos:broaderTransitive[@rdf:resource=$aktuelltKoncept])!=1">
-										 (Korrekt BT för <xsl:value-of select="skos:prefLabel"/> saknas.)
+										 <p class="error">Konceptet med föredraget namn &quot;<xsl:value-of select="skos:prefLabel"/>&quot; saknar skos:broader till detta koncept.</p>
 										</xsl:if>
 									</xsl:for-each>
 									
@@ -220,7 +251,7 @@ xmlns:dc="http://purl.org/dc/elements/1.1/">
 		
 									<xsl:for-each select="//skos:Concept[@rdf:about=$relateradTerm]">
 										<xsl:if test="count(skos:related[@rdf:resource=$aktuelltKoncept])!=1">
-										 (Korrekt RT för <xsl:value-of select="skos:prefLabel"/> saknas.)
+										 <p class="error">Konceptet med föredraget namn &quot;<xsl:value-of select="skos:prefLabel"/>&quot; saknar skos:related till detta koncept.</p>
 										</xsl:if>
 									</xsl:for-each>
 									
@@ -245,11 +276,11 @@ xmlns:dc="http://purl.org/dc/elements/1.1/">
 												</xsl:attribute>
 												<xsl:value-of select="."/>
 											</a>
-											<br/>
+<br />
 										</xsl:for-each>
 									</xsl:if>
 									<xsl:value-of select="."/>
-									<br/>
+									
 								</xsl:for-each>
 							</div>
 						</div>
@@ -281,8 +312,9 @@ xmlns:dc="http://purl.org/dc/elements/1.1/">
 	<xsl:template match="skos:altLabel">
 		<div class="post clear">
 			<div class="uppslag alt">
+<p>
 				<xsl:value-of select="."/>
-				<p>(icke föredragen term)</p>
+				(icke föredragen term)</p>
 			</div>
 			<div class="right">
 				<div class="notering alt">Använd i stället (USE):</div>
@@ -333,7 +365,8 @@ xmlns:dc="http://purl.org/dc/elements/1.1/">
 				</xsl:otherwise>
 			</xsl:choose>
 		</xsl:for-each>
-		<xsl:if test="count(//skos:Concept[@rdf:about=$namn])!=1">Felaktigt attributnamn: <xsl:value-of select="$namn"/></xsl:if>
+		<xsl:if test="count(//skos:Concept[@rdf:about=$namn])=0"><p class="error">Du har hänvisat till ett koncept med id  <xsl:value-of select="$namn"/>, men vokabulären saknar ett koncept med detta id.</p></xsl:if>
+		<!--xsl:if test="count(//skos:Concept[@rdf:about=$namn])>1"><p class="error">Du har hänvisat till ett koncept med id  <xsl:value-of select="$namn"/>, men det finns fler än ett koncept med detta id i din vokabulär.</p></xsl:if-->
 	</xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Dvs samma version som för närvarande ligger som skos-styleList.xsl i den andra mappen (men hittar inget sätt att länka mellan mapparna?). Största skillnaden för visning är bredare mellanrum mellan uppslagsord och resten. I övrigt är det nog mest felsökningsstödet som är uppdaterat jämfört med första versionen.